### PR TITLE
Fixed links

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -41,4 +41,4 @@ At the moment, Fire★ only provides official builds for Ubuntu and Windows (alt
 Support
 -------
 
-If you are having issues, please let us know on the [issue tracker](https://github.com/mempko/firestr/issues), the irc channel (quickstart#firestr on freenode), or the [Mailing List](mailto:firestr@librelist.com) and we'll try our best to help out.
+If you are having issues, please let us know on the [issue tracker](https://github.com/mempko/firestr/issues), the irc channel (#firestr on freenode), or the [Mailing List](mailto:firestr@librelist.com) and we'll try our best to help out.


### PR DESCRIPTION
For some reason readthedocs handles markdown links strangely.  This pull request fixes a bug caused by that where a link like [Ubuntu](#ubuntu) on a file other than index.md would link to index.md#ubuntu
