### PR TITLE
added missing deps

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,6 +6,7 @@ Boost
 Botan 1.10
 libsnappy
 libopus
+libxss
 
 Building Firestr
 ===================================================================

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,14 +1,14 @@
 Library Dependencies
 ===================================================================
-gcc 4.7
-Qt 5
-Boost
-Botan 1.10
-libsnappy
-libopus
-libxss
-uuid
-libgmp
+* gcc 4.7
+* Qt 5
+* Boost
+* Botan 1.10
+* libsnappy
+* libopus
+* libxss
+* uuid
+* libgmp
 
 Building Firestr
 ===================================================================

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,6 +7,8 @@ Botan 1.10
 libsnappy
 libopus
 libxss
+uuid
+libgmp
 
 Building Firestr
 ===================================================================


### PR DESCRIPTION
When building, firestr requires `X11/extensions/scrnsaver.h`, which is provided by `libxss-dev`, and is not provided on some platforms.

When linking, firestr requires `uuid-dev` and `libgmp-dev`, but these are not listed.